### PR TITLE
Update setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ esl = Extension(
              'ESL/esl_threadmutex.c',
              'ESL/esl_oop.cpp',
              'ESL/ESL.i'],
-    swig_opts=['-classic', '-c++', '-DMULTIPLICITY', '-threads', '-I./ESL'],
+    swig_opts=['-c++', '-DMULTIPLICITY', '-threads', '-I./ESL'],
     extra_compile_args=['-I./ESL']
 )
 


### PR DESCRIPTION
The -classic option is no longer supported in newer SWIG versions, so it breaks the install of the package.